### PR TITLE
feat: redirect to first chapter on root init

### DIFF
--- a/src/UIBook.elm
+++ b/src/UIBook.elm
@@ -540,7 +540,14 @@ init props _ url navKey =
       , actionLogModal = False
       , isMenuOpen = False
       }
-    , maybeRedirect navKey activeChapter
+    , case activeChapter of
+        Just _ ->
+            Cmd.none
+
+        Nothing ->
+            Array.get 0 chapters
+                |> Maybe.map (Nav.replaceUrl navKey << urlFromChapter props.config.urlPreffix)
+                |> Maybe.withDefault Cmd.none
     )
 
 

--- a/src/UIBook.elm
+++ b/src/UIBook.elm
@@ -547,7 +547,7 @@ init props _ url navKey =
         Nothing ->
             Array.get 0 chapters
                 |> Maybe.map (Nav.replaceUrl navKey << urlFromChapter props.config.urlPreffix)
-                |> Maybe.withDefault Cmd.none
+                |> Maybe.withDefault (Nav.replaceUrl navKey "/")
     )
 
 
@@ -651,7 +651,12 @@ update msg model =
                         | chapterActive = activeChapter
                         , isMenuOpen = False
                       }
-                    , maybeRedirect model.navKey activeChapter
+                    , case activeChapter of
+                        Just _ ->
+                            Cmd.none
+
+                        Nothing ->
+                            Nav.replaceUrl model.navKey "/"
                     )
 
         UpdateState fn ->


### PR DESCRIPTION
Closes #11 

Changes how the init and update methods discrimantes between the starting page. Using the urlFromChapter method, it either navigates to the first chapter page or to a starting blank page in case of an empty list of chapters.
