### PR TITLE
feat: provide theme css var

### DIFF
--- a/src/UIBook/Widgets/Helpers.elm
+++ b/src/UIBook/Widgets/Helpers.elm
@@ -2,7 +2,27 @@ module UIBook.Widgets.Helpers exposing (..)
 
 import Css exposing (..)
 import Css.Media exposing (only, screen, withMedia)
+import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (..)
+
+
+
+-- Theme Color
+
+
+themeVar : String
+themeVar =
+    "--ui-book-theme"
+
+
+setThemeColor : String -> Attribute msg
+setThemeColor color =
+    attribute "style" (themeVar ++ ":" ++ color ++ ";")
+
+
+themeColor : String
+themeColor =
+    "var(" ++ themeVar ++ ")"
 
 
 

--- a/src/UIBook/Widgets/Wrapper.elm
+++ b/src/UIBook/Widgets/Wrapper.elm
@@ -78,7 +78,10 @@ view :
     }
     -> Html msg
 view props =
-    div [ css [ backgroundColor (hex "#fff") ] ]
+    div
+        [ css [ backgroundColor (hex "#fff") ]
+        , setThemeColor props.color
+        ]
         [ div [ css [ display none ] ] props.globals
         , div
             [ css


### PR DESCRIPTION
Provides a css variable set to the UIBook's theme color. It can be used like this:

```elm
import UIBook.Widgets.Helpers exposing (themeColor)
import Css

div [
    css [ Css.style "color" themeColor ]
] []
```